### PR TITLE
Resolve bugs on Rakudo 2017.07

### DIFF
--- a/lib/Avro/Auxiliary.pm
+++ b/lib/Avro/Auxiliary.pm
@@ -1,5 +1,6 @@
 use v6;
 use JSON::Tiny;
+use experimental :pack;
 
 package Avro {
 
@@ -99,11 +100,7 @@ package Avro {
     has Int $!size;
     has Buf $!stream;
 
-    multi method new(){
-      self.bless( blob => pack("") );
-    }
-
-    multi method new(Blob :$blob) {
+    multi method new(Blob :$blob = pack '') {
       self.bless( blob => $blob );
     }
 
@@ -111,7 +108,6 @@ package Avro {
       $!index = 0;
       $!stream = $blob;
       $!size = $!stream.elems();
-      CATCH { default { $!size = 0 } } #empty buffers become undefined?
     }
 
     method !resize() {
@@ -137,7 +133,6 @@ package Avro {
         }
       }
       $!size = $!stream.elems();
-      CATCH { default { $!size = 0 } } # same issue
     }
 
     method blob (--> Blob) {

--- a/lib/Avro/DataFile.pm
+++ b/lib/Avro/DataFile.pm
@@ -48,7 +48,7 @@ package Avro {
   #   constructors of reader and writer
   #======================================
 
-  enum Encoding is export <JSON Binary>; 
+  enum Encoding <JSON Binary>;
 
 
   #== Enum ==============================
@@ -56,7 +56,7 @@ package Avro {
   #   -- the codec, used by the writer
   #======================================
 
-  enum Codec is export <null deflate>;
+  enum Codec <null deflate>;
 
 
   #== Class =============================


### PR DESCRIPTION
This gets things working on Rakudo 2017.07 and unbusts all tests except for 'Writing bytes for small number'.